### PR TITLE
Deleted package-lock.json at root level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Don't think it's needed, and scanning tools get confused by it.